### PR TITLE
Add a new feature to create only one midi file per layer

### DIFF
--- a/src/Arranging/ArrangeSections.py
+++ b/src/Arranging/ArrangeSections.py
@@ -7,11 +7,11 @@ import CreateMidiEventsForBass
 
 class ArrangeSections : 
 
-    def __init__ ( self, id, movement, outdir ) : 
+    def __init__ ( self, id, movement, outdir , oneMidiPerLayer) : 
         self.id = id
         self.movement = movement
         self.outdir   = outdir
-
+        self.oneMidiPerLayer = oneMidiPerLayer
         
     def arrange ( self ) : 
 
@@ -40,7 +40,7 @@ class ArrangeSections :
 
 
         self.midiEventsForSectionLayers = collections.OrderedDict() 
-
+        
 
         sectionsObj = self.movement['SectionsObj'].mood
         for secId in sectionsObj.sections : 
@@ -193,12 +193,18 @@ class ArrangeSections :
                         self.midiEventsForSectionLayers[secId][layer] += CreateMidiEventsForBass.CreateMidiEventsForStrings ( layer, uniqCPId, secId, phId, repCount, numChordsInSection, sectionsObj.sections[secId]['phrases'][phId], self.movement['layers'][uniqCPId][layer] )  
 
 
-
+        self.midiEventsForLayers = collections.OrderedDict()
+        for secId in self.midiEventsForSectionLayers :
+            for layer in self.midiEventsForSectionLayers[secId] : 
+                #print("Layer: ",layer,"len: ",len(self.midiEventsForLayers))
+                if (self.midiEventsForLayers.get(layer,"0") == "0" ) :
+                    #print(layer)
+                    self.midiEventsForLayers[layer] = []
+ 
         for secId in self.midiEventsForSectionLayers : 
             for layer in self.midiEventsForSectionLayers[secId] : 
-
-                CreateMidiEventsForBass.CreateMidiFileForBass ( self.id, secId, layer, self.midiEventsForSectionLayers[secId][layer], self.outdir ) 
-
+                self.midiEventsForLayers[layer].extend(self.midiEventsForSectionLayers[secId][layer])
+                
                 #if ( layer == 'bass1' or layer == 'bass2'  or layer == 'mel5' or layer == 'piano1' or layer == 'rhythmChords' ) : 
                 #    CreateMidiEventsForBass.CreateMidiFileForBass ( self.id, secId, layer, self.midiEventsForSectionLayers[secId][layer] ) 
                     
@@ -207,5 +213,23 @@ class ArrangeSections :
                     for ev in self.midiEventsForSectionLayers[secId][layer] : 
                         print ( ev ) 
                     print() 
+        if self.oneMidiPerLayer:
+            for layer in self.midiEventsForLayers :
+                CreateMidiEventsForBass.CreateMidiFileForBass ( self.id, 1, layer, self.midiEventsForLayers[layer], self.outdir ) 
+        else:
+            for secId in self.midiEventsForSectionLayers : 
+                for layer in self.midiEventsForSectionLayers[secId] : 
+
+                    CreateMidiEventsForBass.CreateMidiFileForBass ( self.id, secId, layer, self.midiEventsForSectionLayers[secId][layer], self.outdir ) 
+
+                    #if ( layer == 'bass1' or layer == 'bass2'  or layer == 'mel5' or layer == 'piano1' or layer == 'rhythmChords' ) : 
+                    #    CreateMidiEventsForBass.CreateMidiFileForBass ( self.id, secId, layer, self.midiEventsForSectionLayers[secId][layer] ) 
+                    
+                    if ( 0 and layer.startswith('mel5High') ) : 
+                        print ( "Section: ", secId, "Layer: ", layer ) 
+                        for ev in self.midiEventsForSectionLayers[secId][layer] : 
+                            print ( ev ) 
+                        print() 
+
 
             

--- a/src/Arranging/CreateMidiEventsForBass.py
+++ b/src/Arranging/CreateMidiEventsForBass.py
@@ -402,6 +402,7 @@ def CreateMidiFileForBass ( mvNum, secId, layer, midiEvents, outdir ) :
 
     foutName = outdir + "WB_Mvmt" + str(mvNum) + "_Sec" + str(secId) + "_" + layer 
     fout = open ( foutName + ".py", mode='w' ) 
+    print("ouput " + foutName)
         
     
     WriteInitialMidiFileSequence ( fout ) 
@@ -449,11 +450,11 @@ def WriteFinalMidiFileSequence (  fout, foutName ) :
     fout.write ( "\nmidi.write_midifile(\"%s\", pattern)" %(foutMidiName) ) ;
     fout.close() ;
         
-    #print ( "\nOutput midi file: %s\n" %(foutMidiName) ) ;
+    print ( "\nOutput midi file: %s\n" %(foutMidiName) ) ;
     call = "python " + foutName + ".py"  ; 
     os.system ( call ) ;
-    call = "rm " + foutName + ".py"  ; 
-    os.system ( call ) ;
+    #call = "rm " + foutName + ".py"  ; 
+    #os.system ( call ) ;
     
 
 def WriteInitialMidiFileSequence (  fout ) : 

--- a/src/Skeleton/Skeleton.py
+++ b/src/Skeleton/Skeleton.py
@@ -19,12 +19,13 @@ import DevServer.Server
 class Template : 
 
 
-    def __init__ ( self, iniFname, midiFilePath, outDir ) : 
+    def __init__ ( self, iniFname, midiFilePath, outDir,oneMidiPerLayer) : 
  
         self.tempo = None           
         self.midiFilePath = midiFilePath
         self.outDir = outDir
         self.ReadIniFile ( iniFname ) 
+        self.oneMidiPerLayer = oneMidiPerLayer
 
         #Initialize mood and sections
         for mvNum in self.movements : 
@@ -374,7 +375,7 @@ class Template :
                 self.movements[mvNum]['layers'][uniqCPId] = section.run () 
 
                 
-            arrangeSections = ArrangeSections ( mvNum, self.movements[mvNum], self.outDir ) 
+            arrangeSections = ArrangeSections ( mvNum, self.movements[mvNum], self.outDir ,self.oneMidiPerLayer) 
             arrangeSections.arrange() 
 
 
@@ -454,7 +455,7 @@ def usage() :
 
 def run () : 
 
-
+    print("in skeleton")
     parser = argparse.ArgumentParser()
 
     parser.add_argument('-i', action='store',
@@ -472,11 +473,13 @@ def run () :
                         default='./output/',
                         help='Output File Path')
 
+    parser.add_argument('-l', action='store_true',
+                        dest='oneMidiPerLayer',
+                        help="One midi per layer"  ) 
 
     parser.add_argument('-u', action='store_true',
                         dest='usage',
-                        help="usage"  ) 
-    
+                        help="usage"  )
     
     results = parser.parse_args()
 
@@ -499,6 +502,7 @@ def run () :
     print('iniFile          = {!r}'.format(results.iniFile ))
     print('midiFile         = {!r}'.format(results.midiFilePath ))
     print('outputDir        = {!r}'.format(results.outputFilePath ))
+    print('layerpermidi        = {!r}'.format(results.oneMidiPerLayer ))
 
 
     rmCmd = "rm -rf {}/WB*.mid {}/WB*.py".format( results.outputFilePath, results.outputFilePath ) 
@@ -506,7 +510,7 @@ def run () :
 
     #random.seed ( 10 )
 
-    skeleton = Template( results.iniFile, results.midiFilePath, results.outputFilePath ) 
+    skeleton = Template( results.iniFile, results.midiFilePath, results.outputFilePath,results.oneMidiPerLayer) 
 
 
 


### PR DESCRIPTION
The new feature has a new command line option "-l" which bypasses creating
one midi file per section per layer and instead creates only one
midi file per layer