### PR TITLE
Fix Issue #17 - Syntax Error 

### DIFF
--- a/src/mididump.py
+++ b/src/mididump.py
@@ -6,9 +6,9 @@ import midi
 import sys
 
 if len(sys.argv) != 2:
-    print "Usage: {0} <midifile>".format(sys.argv[0])
+    print("Usage: {0} <midifile>").format(sys.argv[0])
     sys.exit(2)
 
 midifile = sys.argv[1]
 pattern = midi.read_midifile(midifile)
-print repr(pattern)
+print(repr(pattern))


### PR DESCRIPTION
Simply missing parentheses in mididump.py. Was using Python3 syntax but rest of project is in Python2

Tested this locally on Mac OSX 10.13.6 and Python 2.7.12

https://github.com/cognitive-catalyst/watson-beat/issues/17